### PR TITLE
Revert "Fixed backend and UI load functions to correctly recognize and apply display config files"

### DIFF
--- a/DAIRemote/DAIRemoteApplicationUI.cs
+++ b/DAIRemote/DAIRemoteApplicationUI.cs
@@ -97,17 +97,7 @@ namespace DAIRemote
 
         private void BtnLoadDisplayConfig_Click(object sender, EventArgs e)
         {
-            string fileName = profileNameTextBox.Text;
-            if (fileName != "")
-            {
-                DisplayConfig.SetDisplaySettings(fileName + ".json");
-            }
-            else
-            {
-                MessageBox.Show("Invalid input, name cannot be empty");
-            }
-
-            profileNameTextBox.Clear();
+            DisplayConfig.SetDisplaySettings("displayConfig" + ".json");
         }
     }
 }

--- a/DisplayProfileManager/DisplayConfig.cs
+++ b/DisplayProfileManager/DisplayConfig.cs
@@ -1020,15 +1020,6 @@ namespace DisplayProfileManager
 
         public static bool SetDisplaySettings(string fileName)
         {
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            string folderPath = Path.Combine(appDataPath, "DAIRemote");
-
-            if (!Directory.Exists(folderPath))
-            {
-                Directory.CreateDirectory(folderPath);
-            }
-            fileName = Path.Combine(folderPath, fileName);
-
             debugMsg("Loading display settings from file: " + fileName);
             if (!File.Exists(fileName))
             {
@@ -1304,28 +1295,6 @@ namespace DisplayProfileManager
 
             return false;
         }
-
-        /*public static bool DeleteDisplaySettings(string fileName)
-        {
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            string folderPath = Path.Combine(appDataPath, "DAIRemote");
-
-            if (!Directory.Exists(folderPath))
-            {
-                Directory.CreateDirectory(folderPath);
-            }
-            fileName = Path.Combine(folderPath, fileName);
-
-            debugMsg("Deleting display settings on file: " + fileName);
-            if (!File.Exists(fileName))
-            {
-                Debug.WriteLine("ERROR: Display settings file does not exist: " + fileName);
-                return false;
-            }
-
-            File.Delete(fileName);
-            return false;
-        }*/
         static void Main(string[] args)
         {
 


### PR DESCRIPTION
Reverts WSU-4110/DAIRemote#57

Pull request #57's directory must be updated to include the new subfolder for display profiles. Additionally, loading should aim to search for the available files as the system tray implementation does, rather than requiring the user to manually enter a display profile name off recollection alone.