### PR TITLE
Implemented Retrieving Host's Mute Status & Handling of No Audio Devices/Display Profiles

### DIFF
--- a/DAIRemoteApp/app/src/main/java/com/example/dairemote_app/AudioRecyclerAdapter.java
+++ b/DAIRemoteApp/app/src/main/java/com/example/dairemote_app/AudioRecyclerAdapter.java
@@ -53,27 +53,34 @@ public class AudioRecyclerAdapter extends RecyclerView.Adapter<AudioRecyclerAdap
 
     @Override
     public void onBindViewHolder(@NonNull OptionViewHolder holder, int position) {
-        holder.button.setText(audioDevices.get(position));
-
-        if (position == selectedPosition) {
-            holder.button.setBackgroundColor(Color.parseColor("#044a41"));
+        if ("No audio devices".equals(audioDevices.get(position))) {
+            holder.button.setText("No Audio Devices");
+            holder.button.setEnabled(false);
+            holder.button.setBackgroundColor(Color.GRAY);
+            holder.button.setOnClickListener(null); // Remove click listener
         } else {
-            holder.button.setBackgroundColor(Color.parseColor("#077063"));
-        }
+            holder.button.setText(audioDevices.get(position));
 
-        holder.button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                MainActivity.connectionManager.SendHostMessage("AudioConnect " + holder.button.getText().toString());
-                int previousPosition = selectedPosition;
-                selectedPosition = holder.getAdapterPosition();
-
-                if (previousPosition != -1) {
-                    notifyItemChanged(previousPosition);
-                }
-                notifyItemChanged(selectedPosition);
+            if (position == selectedPosition) {
+                holder.button.setBackgroundColor(Color.parseColor("#044a41"));
+            } else {
+                holder.button.setBackgroundColor(Color.parseColor("#077063"));
             }
-        });
+
+            holder.button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    MainActivity.connectionManager.SendHostMessage("AudioConnect " + holder.button.getText().toString());
+                    int previousPosition = selectedPosition;
+                    selectedPosition = holder.getAdapterPosition();
+
+                    if (previousPosition != -1) {
+                        notifyItemChanged(previousPosition);
+                    }
+                    notifyItemChanged(selectedPosition);
+                }
+            });
+        }
     }
 
     @Override

--- a/DAIRemoteApp/app/src/main/java/com/example/dairemote_app/DisplayProfilesRecyclerAdapter.java
+++ b/DAIRemoteApp/app/src/main/java/com/example/dairemote_app/DisplayProfilesRecyclerAdapter.java
@@ -1,5 +1,6 @@
 package com.example.dairemote_app;
 
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,13 +27,21 @@ public class DisplayProfilesRecyclerAdapter extends RecyclerView.Adapter<Display
 
     @Override
     public void onBindViewHolder(@NonNull OptionViewHolder holder, int position) {
-        holder.button.setText(displayProfiles.get(position));
-        holder.button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                MainActivity.connectionManager.SendHostMessage("DisplayConnect " + holder.button.getText().toString());
-            }
-        });
+        if ("No display profiles".equals(displayProfiles.get(position))) {
+            holder.button.setText("No Display Profiles");
+            holder.button.setEnabled(false);
+            holder.button.setBackgroundColor(Color.GRAY);
+            holder.button.setOnClickListener(null); // Remove click listener
+        } else {
+            holder.button.setText(displayProfiles.get(position));
+            holder.button.setBackgroundColor(Color.parseColor("#077063"));
+            holder.button.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    MainActivity.connectionManager.SendHostMessage("DisplayConnect " + holder.button.getText().toString());
+                }
+            });
+        }
     }
 
     @Override

--- a/UDPServerManager/UDPServerManager.cs
+++ b/UDPServerManager/UDPServerManager.cs
@@ -346,9 +346,22 @@ public class UDPServerHost
                 else if (parts[1] == "Devices")
                 {
                     List<string> devices = audioManager.ActiveDeviceNames;
-                    string list = string.Join(",", devices);
+                    if (devices.Count > 0)
+                    {
+                        string list = string.Join(",", devices);
 
-                    SendUdpMessage("AudioDevices: " + list + "|Volume: " + audioManager.GetVolume() + "|DefaultAudioDevice: " + audioManager.GetDefaultAudioDevice().FullName);
+                        SendUdpMessage("AudioDevices: " + list
+                            + "|Volume: " + audioManager.GetVolume()
+                            + "|DefaultAudioDevice: " + audioManager.GetDefaultAudioDevice().FullName
+                            + "|Mute: " + audioManager.GetDefaultAudioDevice().IsMuted);
+                    }
+                    else
+                    {
+                        SendUdpMessage("AudioDevices: "
+                            + "|Volume: 0"
+                            + "|DefaultAudioDevice: None"
+                            + "|Mute: true");
+                    }
                 }
                 else if (parts[1] == "TogglePlay")
                 {
@@ -378,10 +391,17 @@ public class UDPServerHost
                 {
                     // Get all .json files from the directory (display profiles)
                     string[] displayProfiles = Directory.GetFiles(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DAIRemote/DisplayProfiles"), "*.json");
-                    string displayProfileName = string.Join(",", Array.ConvertAll(displayProfiles, Path.GetFileNameWithoutExtension));
 
-                    Debug.WriteLine(displayProfileName);
-                    SendUdpMessage("DisplayProfiles: " + displayProfileName);
+                    if (displayProfiles.Length > 0)
+                    {
+                        string displayProfileName = string.Join(",", Array.ConvertAll(displayProfiles, Path.GetFileNameWithoutExtension));
+                        Debug.WriteLine(displayProfileName);
+                        SendUdpMessage("DisplayProfiles: " + displayProfileName);
+                    }
+                    else
+                    {
+                        SendUdpMessage("DisplayProfiles: ");
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
* Implemented retrieving the hosts mute status to ensure client's mute status aligns with host.
* Implemented placeholders that do nothing and notify the user of no audio devices or display profiles accordingly when the respective list is empty.