### PR TITLE
Audio Refreshing, System Tray Updating, & Easier Form Input

### DIFF
--- a/AudioManager/AudioDeviceManager.cs
+++ b/AudioManager/AudioDeviceManager.cs
@@ -57,11 +57,11 @@ public class AudioDeviceManager
 
     public void SetDefaultAudioDevice(CoreAudioDevice audioDevice)
     {
-		if (audioDevice != this.defaultAudioDevice)
-		{
-			this.defaultAudioDevice = audioDevice;
-			this.defaultAudioDevice.SetAsDefault();
-		}
+        if (audioDevice != this.defaultAudioDevice)
+        {
+            this.defaultAudioDevice = audioDevice;
+            this.defaultAudioDevice.SetAsDefault();
+        }
     }
 
     public void SetDefaultAudioDevice(string deviceFullName)
@@ -70,10 +70,10 @@ public class AudioDeviceManager
 
         if (matchedDevice != null)
         {
-			if ((matchedDevice != this.defaultAudioDevice))
-			{
-				SetDefaultAudioDevice(matchedDevice);
-			}
+            if ((matchedDevice != this.defaultAudioDevice))
+            {
+                SetDefaultAudioDevice(matchedDevice);
+            }
         }
         else
         {
@@ -97,13 +97,13 @@ public class AudioDeviceManager
 
     public void SetVolume(double volume)
     {
-		this.defaultAudioDevice.Volume = volume;
+        this.defaultAudioDevice.Volume = volume;
     }
 
-	public double GetVolume()
-	{
-		return this.defaultAudioDevice.Volume;
-	}
+    public double GetVolume()
+    {
+        return this.defaultAudioDevice.Volume;
+    }
 
     public void IncreaseVolume(int increment = 1)
     {
@@ -146,18 +146,21 @@ public class AudioDeviceManager
 
     public void ToggleAudioMute()
     {
-		SetAudioMute(!this.defaultAudioDevice.IsMuted);
+        SetAudioMute(!this.defaultAudioDevice.IsMuted);
     }
 
     public void CycleAudioDevice()
     {
-        // Get the index of the current default device
-        int currentIndex = audioDevices.FindIndex(device => device.Id == defaultAudioDevice.Id);
-        // Calculate the next index in a circular manner
-        int nextIndex = (currentIndex + 1) % audioDevices.Count;
-        // Set the next device as the default audio device
-        SetDefaultAudioDevice(audioDevices[nextIndex]);
-        Debug.WriteLine($"Switched to {defaultAudioDevice.FullName}");
-        AudioDevicesUpdated?.Invoke(ActiveDeviceNames);
+        if (this.audioDevices.Count > 1)
+        {
+            // Get the index of the current default device
+            int currentIndex = audioDevices.FindIndex(device => device.Id == defaultAudioDevice.Id);
+            // Calculate the next index in a circular manner
+            int nextIndex = (currentIndex + 1) % audioDevices.Count;
+            // Set the next device as the default audio device
+            SetDefaultAudioDevice(audioDevices[nextIndex]);
+            Debug.WriteLine($"Switched to {defaultAudioDevice.FullName}");
+            AudioDevicesUpdated?.Invoke(ActiveDeviceNames);
+        }
     }
 }

--- a/AudioManager/AudioDeviceManager.cs
+++ b/AudioManager/AudioDeviceManager.cs
@@ -54,7 +54,7 @@ public class AudioDeviceManager
 
     public void RefreshAudioDeviceSubscriptions()
     {
-        audioController.Dispose();
+        audioController?.Dispose();
         audioController = new CoreAudioController();
         SetAudioDefaults();
         SubscribeAudioDevices();

--- a/AudioManager/AudioDeviceManager.cs
+++ b/AudioManager/AudioDeviceManager.cs
@@ -24,12 +24,7 @@ public class AudioDeviceManager
 
         // Set the initial values for variables needed for functions
         SetAudioDefaults();
-
-        // Subscribe all playback devices, even inactive ones
-        foreach (CoreAudioDevice device in audioController.GetPlaybackDevices())
-        {
-            device.StateChanged.Subscribe(OnAudioDeviceChanged);
-        }
+        SubscribeAudioDevices();
     }
 
     private void SetAudioDefaults()
@@ -44,6 +39,25 @@ public class AudioDeviceManager
     {
         Debug.WriteLine($"Audio device state changed for: {args.Device.FullName}");
         SetAudioDefaults();
+        AudioDevicesUpdated?.Invoke(ActiveDeviceNames);
+    }
+
+    public void SubscribeAudioDevices()
+    {
+        // Subscribe all playback devices, even inactive ones
+        foreach (CoreAudioDevice device in audioController.GetPlaybackDevices())
+        {
+            Debug.WriteLine($"for: {device.FullName}");
+            device.StateChanged.Subscribe(OnAudioDeviceChanged);
+        }
+    }
+
+    public void RefreshAudioDeviceSubscriptions()
+    {
+        audioController.Dispose();
+        audioController = new CoreAudioController();
+        SetAudioDefaults();
+        SubscribeAudioDevices();
         AudioDevicesUpdated?.Invoke(ActiveDeviceNames);
     }
 

--- a/DAIRemote/DAIRemoteApplicationUI.cs
+++ b/DAIRemote/DAIRemoteApplicationUI.cs
@@ -33,6 +33,16 @@ public partial class DAIRemoteApplicationUI : Form
         SetStartupStatus();   // Checks onStartup default value to set
         InitializeDisplayProfilesLayouts(); // Initialize load and delete display profile flow layouts
         InitializeDisplayProfilesList();    // Initialize the form & listbox used for showing display profiles list
+
+        // Listen for display profile changes
+        FileSystemWatcher displayProfileDirWatcher = new(DisplayConfig.GetDisplayProfilesDirectory())
+        {
+            NotifyFilter = NotifyFilters.FileName
+        };
+        displayProfileDirWatcher.Created += OnProfilesChanged;
+        displayProfileDirWatcher.Deleted += OnProfilesChanged;
+        displayProfileDirWatcher.Renamed += OnProfilesChanged;
+        displayProfileDirWatcher.EnableRaisingEvents = true;
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -45,6 +55,21 @@ public partial class DAIRemoteApplicationUI : Form
 
             this.Invoke((MethodInvoker)(() => InitializeAudioDropDown()));
         });
+    }
+
+    private void OnProfilesChanged(object sender, FileSystemEventArgs e)
+    {
+        if (this.InvokeRequired)
+        {
+            this.BeginInvoke((MethodInvoker)delegate
+            {
+                InitializeDisplayProfilesLayouts();
+            });
+        }
+        else
+        {
+            InitializeDisplayProfilesLayouts();
+        }
     }
 
     private void InitializeDisplayProfilesLayouts()
@@ -87,7 +112,6 @@ public partial class DAIRemoteApplicationUI : Form
         Button clickedButton = sender as Button;
         string profileName = clickedButton.Tag.ToString();
         DisplayConfig.DeleteDisplaySettings(profileName);
-        InitializeDisplayProfilesLayouts();
     }
 
     private void LoadProfileButton_Click(object sender, EventArgs e)
@@ -95,7 +119,6 @@ public partial class DAIRemoteApplicationUI : Form
         Button clickedButton = sender as Button;
         string profileName = clickedButton.Tag.ToString();
         DisplayConfig.SetDisplaySettings(profileName);
-        InitializeDisplayProfilesLayouts();
     }
 
     private void DAIRemoteApplicationUI_FormClosing(object sender, FormClosingEventArgs e)

--- a/DAIRemote/HotkeyManager.cs
+++ b/DAIRemote/HotkeyManager.cs
@@ -157,6 +157,9 @@ public partial class HotkeyManager : Form
         buttonPanel.Controls.Add(okButton);
         buttonPanel.Controls.Add(cancelButton);
 
+        // Set the OK button as the action for Enter key
+        inputForm.AcceptButton = okButton;
+
         if (hotkeyConfigs.ContainsKey(action))
         {
             inputBox.Text = GetHotkeyText(hotkeyConfigs[action]);

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -63,6 +63,7 @@ public class TrayIconManager
             Visible = true
         };
 
+        // Listen for display profile changes
         displayProfileDirWatcher = new FileSystemWatcher(DisplayConfig.GetDisplayProfilesDirectory())
         {
             NotifyFilter = NotifyFilters.FileName
@@ -71,6 +72,9 @@ public class TrayIconManager
         displayProfileDirWatcher.Deleted += OnProfilesChanged;
         displayProfileDirWatcher.Renamed += OnProfilesChanged;
         displayProfileDirWatcher.EnableRaisingEvents = true;
+
+        // Listen to AudioDeviceManager's event handler for notifications
+        audioManager.AudioDevicesUpdated += OnAudioDevicesChanged;
 
         trayIcon.DoubleClick += (s, e) => ShowForm();
     }
@@ -91,6 +95,21 @@ public class TrayIconManager
     }
 
     private void OnProfilesChanged(object sender, FileSystemEventArgs e)
+    {
+        if (form.InvokeRequired)
+        {
+            form.BeginInvoke((MethodInvoker)delegate
+            {
+                PopulateTrayMenu(trayMenu);
+            });
+        }
+        else
+        {
+            PopulateTrayMenu(trayMenu);
+        }
+    }
+
+    private void OnAudioDevicesChanged(List<string> devices)
     {
         if (form.InvokeRequired)
         {
@@ -350,7 +369,6 @@ public class TrayIconManager
         inputForm.Controls.Add(cancelButton);
 
         inputForm.ShowDialog();
-
     }
 
 

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -7,7 +7,6 @@ public class TrayIconManager
     private NotifyIcon trayIcon;
     private ContextMenuStrip trayMenu;
     private Form form;
-    private FileSystemWatcher displayProfileDirWatcher;
     private HotkeyManager hotkeyManager;
     private AudioManager.AudioDeviceManager audioManager;
 
@@ -64,7 +63,7 @@ public class TrayIconManager
         };
 
         // Listen for display profile changes
-        displayProfileDirWatcher = new FileSystemWatcher(DisplayConfig.GetDisplayProfilesDirectory())
+        FileSystemWatcher displayProfileDirWatcher = new(DisplayConfig.GetDisplayProfilesDirectory())
         {
             NotifyFilter = NotifyFilters.FileName
         };
@@ -73,7 +72,7 @@ public class TrayIconManager
         displayProfileDirWatcher.Renamed += OnProfilesChanged;
         displayProfileDirWatcher.EnableRaisingEvents = true;
 
-        // Listen to AudioDeviceManager's event handler for notifications
+        // Listen to AudioDeviceManager's event handler for changes
         audioManager.AudioDevicesUpdated += OnAudioDevicesChanged;
 
         trayIcon.DoubleClick += (s, e) => ShowForm();

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -372,6 +372,9 @@ public class TrayIconManager
         inputForm.Controls.Add(okButton);
         inputForm.Controls.Add(cancelButton);
 
+        // Set the OK button as the action for Enter key
+        inputForm.AcceptButton = okButton;
+
         inputForm.ShowDialog();
     }
 

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -289,6 +289,10 @@ public class TrayIconManager
         menu.Items.Add(deleteProfileMenuItem);
         menu.Items.Add(setHotkeysMenuItem);
 
+        // Allow the user to refresh audio devices
+        // Helpful for when a new device is added
+        // That was not present during application initialization
+        ToolStripMenuItem refreshAudioDevices = new("Refresh Audio Devices", audioIcon, RefreshAudioDevices);
         // Create the icons for making monitors sleep, the about section, and exiting the application
         ToolStripMenuItem turnOffAllMonitorsItem = new("Turn Off All Monitors", turnOffAllMonitorsIcon, TurnOffMonitors);
         ToolStripMenuItem aboutMenuItem = new("About", aboutIcon, OnAboutClick);
@@ -296,6 +300,7 @@ public class TrayIconManager
 
         // Separate sleeping monitors, and add the sleep, about, and exit to the main system tray menu
         menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(refreshAudioDevices);
         menu.Items.Add(turnOffAllMonitorsItem);
         menu.Items.Add(new ToolStripSeparator());
         menu.Items.Add(aboutMenuItem);
@@ -380,6 +385,10 @@ public class TrayIconManager
     private void DeleteProfile(string profilePath)
     {
         File.Delete(profilePath);
+    }
+    private void RefreshAudioDevices(object? sender, EventArgs e)
+    {
+        audioManager.RefreshAudioDeviceSubscriptions();
     }
 
     private void TurnOffMonitors(object? sender, EventArgs e)

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -384,7 +384,7 @@ public class TrayIconManager
 
     private void DeleteProfile(string profilePath)
     {
-        File.Delete(profilePath);
+        DisplayConfig.DeleteDisplaySettings(profilePath);
     }
     private void RefreshAudioDevices(object? sender, EventArgs e)
     {


### PR DESCRIPTION
* Ensured audio cycle does nothing if more than 1 audio device is not available.
* Ensured system tray updates on audio device changes.
* Added new system tray item that allows the user to refresh audio devices. Helpful for when a new audio device is added that was not available during application initialization.
* Modified DeleteProfile() in system tray to make use of DisplayConfig.DeleteDisplaySettings().
* Implemented filesystemwatcher for desktop application flow layouts to listen to and update accordingly.
* Enabled pressing 'Enter' to complete form inputs for adding a new profile and setting hotkeys.