### PR TITLE
Fixed Watcher Race Conditions & Ensured Application Hotkey Refreshes System Tray

### DIFF
--- a/DAIRemote/DAIRemoteApplicationUI.cs
+++ b/DAIRemote/DAIRemoteApplicationUI.cs
@@ -35,14 +35,8 @@ public partial class DAIRemoteApplicationUI : Form
         InitializeDisplayProfilesList();    // Initialize the form & listbox used for showing display profiles list
 
         // Listen for display profile changes
-        FileSystemWatcher displayProfileDirWatcher = new(DisplayConfig.GetDisplayProfilesDirectory())
-        {
-            NotifyFilter = NotifyFilters.FileName
-        };
-        displayProfileDirWatcher.Created += OnProfilesChanged;
-        displayProfileDirWatcher.Deleted += OnProfilesChanged;
-        displayProfileDirWatcher.Renamed += OnProfilesChanged;
-        displayProfileDirWatcher.EnableRaisingEvents = true;
+        DisplayProfileWatcher.Initialize(DisplayConfig.GetDisplayProfilesDirectory());
+        DisplayProfileWatcher.ProfileChanged += OnProfilesChanged;
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -59,17 +53,10 @@ public partial class DAIRemoteApplicationUI : Form
 
     private void OnProfilesChanged(object sender, FileSystemEventArgs e)
     {
-        if (this.InvokeRequired)
-        {
-            this.BeginInvoke((MethodInvoker)delegate
-            {
-                InitializeDisplayProfilesLayouts();
-            });
-        }
-        else
+        this.BeginInvoke((MethodInvoker)delegate
         {
             InitializeDisplayProfilesLayouts();
-        }
+        });
     }
 
     private void InitializeDisplayProfilesLayouts()
@@ -105,10 +92,6 @@ public partial class DAIRemoteApplicationUI : Form
             deleteProfileButton.Click += DeleteProfileButton_Click;
             DisplayDeleteProfilesLayout.Controls.Add(deleteProfileButton);
         }
-
-        // Ensure the layouts are refreshed
-        DisplayLoadProfilesLayout.Refresh();
-        DisplayDeleteProfilesLayout.Refresh();
     }
 
     private void DeleteProfileButton_Click(object sender, EventArgs e)
@@ -285,6 +268,7 @@ public partial class DAIRemoteApplicationUI : Form
         if (!string.IsNullOrEmpty(profile))
         {
             trayIconManager.GetHotkeyManager().ShowHotkeyInput(profile, () => DisplayConfig.SetDisplaySettings(profile));
+            trayIconManager.RefreshSystemTray();
         }
     }
 }

--- a/DAIRemote/DAIRemoteApplicationUI.cs
+++ b/DAIRemote/DAIRemoteApplicationUI.cs
@@ -105,6 +105,10 @@ public partial class DAIRemoteApplicationUI : Form
             deleteProfileButton.Click += DeleteProfileButton_Click;
             DisplayDeleteProfilesLayout.Controls.Add(deleteProfileButton);
         }
+
+        // Ensure the layouts are refreshed
+        DisplayLoadProfilesLayout.Refresh();
+        DisplayDeleteProfilesLayout.Refresh();
     }
 
     private void DeleteProfileButton_Click(object sender, EventArgs e)

--- a/DAIRemote/DAIRemoteApplicationUI.cs
+++ b/DAIRemote/DAIRemoteApplicationUI.cs
@@ -132,10 +132,15 @@ public partial class DAIRemoteApplicationUI : Form
 
     private void InitializeAudioDropDown()
     {
+        int panelWidth = (int)(this.ClientSize.Width * 0.8);    // 80% of form width
+        int panelHeight = (int)(this.ClientSize.Height * 0.27); // 27% of form height
+        int panelX = 9;                                         // Offset from the left
+        int panelY = this.ClientSize.Height - panelHeight - 16; // Offset from the bottom
+
         this.audioFormPanel = new Panel
         {
-            Location = new System.Drawing.Point(12, 460),
-            Size = new System.Drawing.Size(760, 370),
+            Location = new System.Drawing.Point(panelX, panelY),
+            Size = new System.Drawing.Size(panelWidth, panelHeight),
         };
 
         audioForm = AudioOutputForm.GetInstance(audioManager);

--- a/DAIRemote/DisplayProfileWatcher.cs
+++ b/DAIRemote/DisplayProfileWatcher.cs
@@ -1,0 +1,33 @@
+﻿public static class DisplayProfileWatcher
+{
+    private static FileSystemWatcher fileSystemWatcher;
+    private static readonly object LockObject = new();
+
+    public static event FileSystemEventHandler ProfileChanged;
+
+    public static void Initialize(string directoryPath)
+    {
+        if (fileSystemWatcher != null) return;
+
+        lock (LockObject)
+        {
+            if (fileSystemWatcher == null)
+            {
+                fileSystemWatcher = new FileSystemWatcher(directoryPath)
+                {
+                    NotifyFilter = NotifyFilters.FileName,
+                    EnableRaisingEvents = true
+                };
+
+                fileSystemWatcher.Created += OnProfileChanged;
+                fileSystemWatcher.Deleted += OnProfileChanged;
+                fileSystemWatcher.Renamed += OnProfileChanged;
+            }
+        }
+    }
+
+    private static void OnProfileChanged(object sender, FileSystemEventArgs e)
+    {
+        ProfileChanged?.Invoke(sender, e);
+    }
+}

--- a/DAIRemote/SystemTray.cs
+++ b/DAIRemote/SystemTray.cs
@@ -63,14 +63,8 @@ public class TrayIconManager
         };
 
         // Listen for display profile changes
-        FileSystemWatcher displayProfileDirWatcher = new(DisplayConfig.GetDisplayProfilesDirectory())
-        {
-            NotifyFilter = NotifyFilters.FileName
-        };
-        displayProfileDirWatcher.Created += OnProfilesChanged;
-        displayProfileDirWatcher.Deleted += OnProfilesChanged;
-        displayProfileDirWatcher.Renamed += OnProfilesChanged;
-        displayProfileDirWatcher.EnableRaisingEvents = true;
+        DisplayProfileWatcher.Initialize(DisplayConfig.GetDisplayProfilesDirectory());
+        DisplayProfileWatcher.ProfileChanged += OnProfilesChanged;
 
         // Listen to AudioDeviceManager's event handler for changes
         audioManager.AudioDevicesUpdated += OnAudioDevicesChanged;
@@ -93,34 +87,28 @@ public class TrayIconManager
         return menu;
     }
 
-    private void OnProfilesChanged(object sender, FileSystemEventArgs e)
+    public void RefreshSystemTray()
     {
-        if (form.InvokeRequired)
-        {
-            form.BeginInvoke((MethodInvoker)delegate
-            {
-                PopulateTrayMenu(trayMenu);
-            });
-        }
-        else
+        form.BeginInvoke((MethodInvoker)delegate
         {
             PopulateTrayMenu(trayMenu);
-        }
+        });
+    }
+
+    private void OnProfilesChanged(object sender, FileSystemEventArgs e)
+    {
+        form.BeginInvoke((MethodInvoker)delegate
+        {
+            PopulateTrayMenu(trayMenu);
+        });
     }
 
     private void OnAudioDevicesChanged(List<string> devices)
     {
-        if (form.InvokeRequired)
-        {
-            form.BeginInvoke((MethodInvoker)delegate
-            {
-                PopulateTrayMenu(trayMenu);
-            });
-        }
-        else
+        form.BeginInvoke((MethodInvoker)delegate
         {
             PopulateTrayMenu(trayMenu);
-        }
+        });
     }
 
     private void PopulateTrayMenu(ContextMenuStrip menu)
@@ -238,7 +226,6 @@ public class TrayIconManager
             ToolStripMenuItem profileDeleteItem = new(fileName, monitorIcon, (sender, e) => DeleteProfile(profile));
 
             ToolStripMenuItem profileSaveItem = new(fileName, monitorIcon, (sender, e) => SaveProfile(profile));
-
 
             // Setting up hotkey funtionality for each profile
             hotkeyText = hotkeyManager.hotkeyConfigs.ContainsKey(fileName)


### PR DESCRIPTION
* Tried ensuring the audio drop down takes into account different resolutions.
* Fixed race conditions occurring from FileSystemWatcher for the application UI and system tray. 
* Ensured system tray gets refreshed once hotkeys are set through the application UI.
